### PR TITLE
refine README to include installation and add release.sh

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,12 +1,24 @@
-## kn-admin
+# kn-admin
 
-`kn admin` helps for Knative configuration when running on a Kubernetes cluster.
-
-### Description
-
-This kn-admin plugin is designed to help administrators and operators better manage a Knative platform installation with kn CLI.
-The plugin’s main objective is to make administration and operation workflows easier, for instance by making it easy to accomplish
+The `kn admin` is a plugin of Knative client and it is designed to help administrators and operators better manage a Knative platform installation with kn CLI.
+This plugin’s main objective is to make administration and operation workflows easier, for instance by making it easy to accomplish
 tasks such as feature flags enablement or disablement with one command, instead of many manual steps like modifying ConfigMaps or yaml files.
+
+## Getting Started
+
+### Installation
+You can download latest binaries from the https://github.com/knative-sandbox/kn-plugin-admin/releases[Releases] page.
+
+Here are two ways to run `kn admin`:
+
+1. You can run it standalone, just put it on your system path, and make sure it is executable.
+2. You can install it as a plugin of `kn` client to run:
+
+- Following the https://github.com/knative/client/blob/master/docs/README.md[document] to install `kn client` if you don't have it.
+- Copy `kn admin` binary to `~/.config/kn/plugins/` folder and make sure its filename is `kn-admin`.
+- Run `kn plugin list` to assure the `kn-admin` plugin is installed successfully.
+
+After the plugin is installed, you can use `kn admin` to run its related subcommands. 
 
 ### Usage
 
@@ -253,3 +265,4 @@ Forwarding from [::1]:18008 -> 8008
 Handling connection for 18008
 -----
 =====
+After you get the profiling data file, you need to use https://blog.golang.org/pprof[pprof] to open it.

--- a/cmd/release.sh
+++ b/cmd/release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright © 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+GIT_REVISION=`git rev-parse --short HEAD`
+VERSION=`date -u '+v%Y%m%d'-`${GIT_REVISION}
+BUILD_DATE=`date -u '+%Y-%m-%d %H:%M:%S'`
+PKG="knative.dev/client-contrib/plugins/admin/pkg/command"
+LD_FLAGS="-X '${PKG}.Version=${VERSION}' -X '${PKG}.BuildDate=${BUILD_DATE}' -X '${PKG}.GitRevision=${GIT_REVISION}'"
+
+export GO111MODULE=on
+export CGO_ENABLED=0
+
+# build for macOS
+echo "🚧 🍏 Building for macOS"
+GOOS=darwin GOARCH=amd64 go build -mod=vendor -ldflags "${LD_FLAGS}" -o kn-admin-darwin-amd64
+# build for linux
+echo "🚧 🐧 Building for Linux"
+GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags "${LD_FLAGS}" -o kn-admin-linux-amd64
+# build for windows
+echo "🚧 🎠 Building for Windows"
+GOOS=windows GOARCH=amd64 go build -mod=vendor -ldflags "${LD_FLAGS}" -o kn-admin-windows-amd64
+


### PR DESCRIPTION
The following changes are for our first release:
1. Refine README.doc to include `installation` part
2. Add `release.sh` to build `kn-admin` for MacOS, Linux and Windows.
3. Follow the `kn client` rules to generate version for `kn-admin`, please see the below examples.

Currently, we still use `module knative.dev/client-contrib/plugins/admin` as module name in our codes. It is maybe changed because we moved into a new repository. I will keep eyes on that and change the `release.sh` as the module name is changed.

* Here is the example of `release.sh` run:
```shell
~/chaozbj/kn-plugin-admin/cmd [chao-refine-readme ✘] ./release.sh
🚧 🍏 Building for macOS
🚧 🐧 Building for Linux
🚧 🎠 Building for Windows
```

* Here is the binaries generated by `release.sh` for all supported platforms:
```shell
~/chaozbj/kn-plugin-admin/cmd [chao-refine-readme ✘] ls -l
total 265064
-rwxr-xr-x  1 chao  staff  44959976 Oct 19 08:35 kn-admin-darwin-amd64
-rwxr-xr-x  1 chao  staff  45356225 Oct 19 08:35 kn-admin-linux-amd64
-rwxr-xr-x  1 chao  staff  45247488 Oct 19 08:35 kn-admin-windows-amd64
-rw-r--r--  1 chao  staff       870 Oct 19 07:52 kn-admin.go
-rwxr-xr-x  1 chao  staff      1414 Oct 19 08:26 release.sh
```

* Here is the `version` outputted by `kn-admin`:
```shell
~/chaozbj/kn-plugin-admin/cmd [chao-refine-readme ✘] ./kn-admin-darwin-amd64 version
Version:      v20201019-e8bf703
Build Date:   2020-10-19 00:35:40
Git Revision: e8bf703
```
