### PR TITLE
Installation method detect

### DIFF
--- a/pkg/command/autoscaling/update.go
+++ b/pkg/command/autoscaling/update.go
@@ -52,6 +52,9 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 			if cmd.Flags().NFlag() == 0 {
 				return errors.New("'autoscaling update' requires flag(s)")
 			}
+			if err := p.EnsureInstallMethodStandalone(); err != nil {
+				return err
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/command/autoscaling/update_test.go
+++ b/pkg/command/autoscaling/update_test.go
@@ -38,7 +38,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewAutoscalingUpdateCommand(&p)
 
@@ -49,7 +50,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	t.Run("config map not exist", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewAutoscalingUpdateCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
@@ -68,7 +70,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewAutoscalingUpdateCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
@@ -93,7 +96,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewAutoscalingUpdateCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--no-scale-to-zero")
@@ -118,7 +122,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewAutoscalingUpdateCommand(&p)
 

--- a/pkg/command/autoscaling/update_test.go
+++ b/pkg/command/autoscaling/update_test.go
@@ -47,6 +47,25 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		assert.ErrorContains(t, err, "'autoscaling update' requires flag(s)", err)
 	})
 
+	t.Run("operator mode should not be supported", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configAutoscaler,
+				Namespace: knativeServing,
+			},
+			Data: make(map[string]string),
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodOperator,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+
+		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
+		assert.ErrorContains(t, err, "Knative managed by operator is not supported yet", err)
+	})
+
 	t.Run("config map not exist", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{

--- a/pkg/command/domain/set.go
+++ b/pkg/command/domain/set.go
@@ -51,6 +51,9 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 			if domain == "" {
 				return errors.New("'domain set' requires the route name provided with the --custom-domain option")
 			}
+			if err := p.EnsureInstallMethodStandalone(); err != nil {
+				return err
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/command/domain/set_test.go
+++ b/pkg/command/domain/set_test.go
@@ -56,7 +56,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 
@@ -67,7 +68,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 	t.Run("config map not exist", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
@@ -84,7 +86,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
@@ -111,7 +114,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 
@@ -136,7 +140,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 		o, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
@@ -164,7 +169,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 
@@ -201,7 +207,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainSetCommand(&p)
 

--- a/pkg/command/domain/set_test.go
+++ b/pkg/command/domain/set_test.go
@@ -65,6 +65,25 @@ func TestNewDomainSetCommand(t *testing.T) {
 		assert.ErrorContains(t, err, "requires the route name", err)
 	})
 
+	t.Run("operator mode should not be supported", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configDomain,
+				Namespace: knativeServing,
+			},
+			Data: make(map[string]string),
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodOperator,
+		}
+		cmd := NewDomainSetCommand(&p)
+
+		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
+		assert.ErrorContains(t, err, "Knative managed by operator is not supported yet", err)
+	})
+
 	t.Run("config map not exist", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{

--- a/pkg/command/domain/unset_test.go
+++ b/pkg/command/domain/unset_test.go
@@ -38,7 +38,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainUnSetCommand(&p)
 
@@ -49,7 +50,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 	t.Run("config map not exist", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainUnSetCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
@@ -68,7 +70,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainUnSetCommand(&p)
 
@@ -89,7 +92,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
-			ClientSet: client,
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
 		}
 		cmd := NewDomainUnSetCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy1.domain")

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -15,10 +15,13 @@
 package pkg
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -29,10 +32,29 @@ var LabelManagedBy = "app.kubernetes.io/managed-by"
 
 // AdminParams stores the configs for interacting with kube api
 type AdminParams struct {
-	KubeCfgPath  string
-	ClientConfig clientcmd.ClientConfig
-	ClientSet    kubernetes.Interface
+	KubeCfgPath        string
+	ClientConfig       clientcmd.ClientConfig
+	ClientSet          kubernetes.Interface
+	InstallationMethod InstallationMethod
 }
+
+// InstallationMethod identify how knative get installed
+type InstallationMethod int
+
+const (
+	// InstallationMethodUnknown default value
+	InstallationMethodUnknown InstallationMethod = iota
+	// InstallationMethodStandalone default installation method using full yaml configurations
+	InstallationMethodStandalone
+	// InstallationMethodOperator installation method using Knative Operator
+	InstallationMethodOperator
+)
+
+// ErrorOperatorModeNotSupport indicates that knative is managed by operator and cannot handled by sub command
+var ErrorOperatorModeNotSupport = errors.New("Knative managed by operator is not supported yet")
+
+// ErrorInstallationMethodUnknown indicates that can not detect current installation method
+var ErrorInstallationMethodUnknown = errors.New("Cannot detect current installation method")
 
 // Initialize generate the clientset for params
 func (params *AdminParams) Initialize() error {
@@ -47,6 +69,40 @@ func (params *AdminParams) Initialize() error {
 			fmt.Println("failed to create client:", err)
 			os.Exit(1)
 		}
+	}
+	if params.InstallationMethod == InstallationMethodUnknown {
+		im, err := params.installationMethod()
+		if err != nil {
+			fmt.Println("failed to get installation method:", err)
+			os.Exit(1)
+		}
+		params.InstallationMethod = im
+	}
+	return nil
+
+}
+
+// installationMethod retrives the installation method
+func (params *AdminParams) installationMethod() (InstallationMethod, error) {
+	cm, err := params.ClientSet.CoreV1().ConfigMaps("knative-serving").Get("config-domain", metav1.GetOptions{})
+	if err != nil {
+		return InstallationMethodUnknown, err
+	}
+	for _, owner := range cm.OwnerReferences {
+		if strings.HasPrefix(owner.APIVersion, "operator.knative.dev") && owner.Kind == "KnativeServing" {
+			return InstallationMethodOperator, nil
+		}
+	}
+	return InstallationMethodStandalone, nil
+}
+
+// EnsureInstallMethodStandalone return error if current installation method is not standalone
+func (params *AdminParams) EnsureInstallMethodStandalone() error {
+	switch params.InstallationMethod {
+	case InstallationMethodOperator:
+		return ErrorOperatorModeNotSupport
+	case InstallationMethodUnknown:
+		return ErrorInstallationMethodUnknown
 	}
 	return nil
 }

--- a/pkg/types_test.go
+++ b/pkg/types_test.go
@@ -1,0 +1,108 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAdminParams_installationMethod(t *testing.T) {
+	t.Run("managed by KnativeOperator", func(t *testing.T) {
+		ptrTrue := true
+		domainCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "operator.knative.dev/v1alpha1",
+						Kind:               "KnativeServing",
+						Name:               "knative-serving",
+						BlockOwnerDeletion: &ptrTrue,
+						Controller:         &ptrTrue,
+					},
+				},
+				Name:      "config-domain",
+				Namespace: "knative-serving",
+			},
+			Data: make(map[string]string),
+		}
+		client := k8sfake.NewSimpleClientset(domainCM)
+
+		params := &AdminParams{
+			ClientSet: client,
+		}
+		got, err := params.installationMethod()
+		if err != nil {
+			t.Error(err)
+		}
+		if got != InstallationMethodOperator {
+			t.Error("Should return InstallationMethodOperator")
+		}
+	})
+
+	t.Run("Installed by standalone mode", func(t *testing.T) {
+		domainCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-domain",
+				Namespace: "knative-serving",
+			},
+			Data: make(map[string]string),
+		}
+		client := k8sfake.NewSimpleClientset(domainCM)
+
+		params := &AdminParams{
+			ClientSet: client,
+		}
+		got, err := params.installationMethod()
+		if err != nil {
+			t.Error(err)
+		}
+		if got != InstallationMethodStandalone {
+			t.Error("Should return InstallationMethodStandalone")
+		}
+	})
+
+}
+
+func TestAdminParams_EnsureInstallMethodStandalone(t *testing.T) {
+	t.Run("Installation method unknown", func(t *testing.T) {
+		params := &AdminParams{}
+		if err := params.EnsureInstallMethodStandalone(); err == nil {
+			t.Error("should return error for unknown installation method")
+		}
+	})
+
+	t.Run("Installation method operator", func(t *testing.T) {
+		params := &AdminParams{
+			InstallationMethod: InstallationMethodOperator,
+		}
+		if err := params.EnsureInstallMethodStandalone(); err == nil {
+			t.Error("should return error for operator installation")
+		}
+	})
+
+	t.Run("Installation method standalone", func(t *testing.T) {
+		params := &AdminParams{
+			InstallationMethod: InstallationMethodStandalone,
+		}
+		if err := params.EnsureInstallMethodStandalone(); err != nil {
+			t.Errorf("should not return error. got %#v", err)
+		}
+	})
+
+}


### PR DESCRIPTION
Detect installation method and return error for domain/autoscaling update operations if installed by KnativeOperator.
In future domain/autoscaling update command should be able to handle operator mode.