### PR TITLE
Quick Fix for pkg import path

### DIFF
--- a/pkg/command/registry/list.go
+++ b/pkg/command/registry/list.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
-	"knative.dev/client-contrib/plugins/admin/pkg"
+	"knative.dev/kn-plugin-admin/pkg"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
 )

--- a/pkg/command/registry/list_test.go
+++ b/pkg/command/registry/list_test.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
-	"knative.dev/client-contrib/plugins/admin/pkg"
-	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
+	"knative.dev/kn-plugin-admin/pkg"
+	"knative.dev/kn-plugin-admin/pkg/testutil"
 	"knative.dev/client/pkg/util"
 )
 


### PR DESCRIPTION
This is caused by the lastest two merged PR 1) import path change 2) registry list (new added files but use old path)