### PR TITLE
fix error import

### DIFF
--- a/pkg/command/registry/list.go
+++ b/pkg/command/registry/list.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
-	"knative.dev/client-contrib/plugins/admin/pkg"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
+	"knative.dev/kn-plugin-admin/pkg"
 )
 
 // NewRegistryListCommand represents the list command


### PR DESCRIPTION
This error import is caused by module name change. Here is details: #10 
After fixed it, I can run `release.sh` to build.
Signed-off-by: chaozbj <zchaocdl@cn.ibm.com>