### PR TITLE
As a Knative administrator, I want to upate autoscaling configs(global) which apply to overall Knative platform.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -233,13 +233,13 @@ $ kn admin registry remove \
 -----
 =====
 
-#### As a Knative administrator, I want to enable scale-to-zero for autoscaling.
+#### As a Knative administrator, I want to update global configs for autoscaling.
 
-.Enable scale-to-zero for autoscaling.
+.Enable scale-to-zero and update stable-window for autoscaling.
 =====
 -----
-$ kn admin autoscaling update --scale-to-zero
-Updated Knative autoscaling config enable-scale-to-zero: true
+$ kn admin autoscaling update --scale-to-zero --stable-window 2m
+Updated Knative autoscaling config
 -----
 =====
 

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v0.17.4
 	knative.dev/client v0.14.0
+	knative.dev/serving v0.14.0
 )

--- a/pkg/command/autoscaling/update.go
+++ b/pkg/command/autoscaling/update.go
@@ -34,19 +34,38 @@ import (
 	as "knative.dev/serving/pkg/apis/autoscaling"
 )
 
-var (
-	scaleToZero                                                         bool
-	enableScaleToZero                                                   = "enable-scale-to-zero"
-	knativeServing                                                      = "knative-serving"
-	configAutoscaler                                                    = "config-autoscaler"
-	stableWindow, scaleToZeroGracePeriod, scaleToZeroPodRetentionPeriod time.Duration
+// Autoscaling global configs
+type Config struct {
+	ScaleToZero                          bool
+	EnableScaleToZero                    string
+	StableWindow                         time.Duration
+	ScaleToZeroGracePeriod               time.Duration
+	ScaleToZeroPodRetentionPeriod        time.Duration
+	ContainerConcurrencyTargetPercentage string
+	PanicWindowPercentage                string
+	PanicThresholdPercentage             string
+	MaxScaleUpRate                       string
+	MaxScaleDownRate                     string
+	TargetBurstCapacity                  string
+	ActivatorCapacity                    string
+	RequestsPerSecondTargetDefault       string
+	ContainerConcurrencyTargetDefault    string
+	PodAutoscalerClass                   string
+}
 
-	containerConcurrencyTargetPercentage, panicWindowPercentage, panicThresholdPercentage, maxScaleUpRate,
-	maxScaleDownRate, targetBurstCapacity, activatorCapacity, requestsPerSecondTargetDefault,
-	containerConcurrencyTargetDefault, podAutoscalerClass string
+func NewConfig() Config {
+	config := Config{}
+	config.EnableScaleToZero = "enable-scale-to-zero"
+	return config
+}
+
+var (
+	knativeServing   = "knative-serving"
+	configAutoscaler = "config-autoscaler"
 )
 
 func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
+	config := NewConfig()
 	AutoscalingUpdateCommand := &cobra.Command{
 		Use:   "update",
 		Short: "Update autoscaling config",
@@ -79,108 +98,108 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 			}
 
 			if cmd.Flags().Changed("scale-to-zero") {
-				desiredCm.Data[enableScaleToZero] = "true"
+				desiredCm.Data[config.EnableScaleToZero] = "true"
 			}
 
 			if cmd.Flags().Changed("no-scale-to-zero") {
-				desiredCm.Data[enableScaleToZero] = "false"
+				desiredCm.Data[config.EnableScaleToZero] = "false"
 			}
 
 			if cmd.Flags().Changed("requests-per-second-target-default") {
-				desiredCm.Data["requests-per-second-target-default"] = fmt.Sprintf("%s", requestsPerSecondTargetDefault)
+				desiredCm.Data["requests-per-second-target-default"] = fmt.Sprintf("%s", config.RequestsPerSecondTargetDefault)
 			}
 
 			if cmd.Flags().Changed("container-concurrency-target-default") {
-				desiredCm.Data["container-concurrency-target-default"] = fmt.Sprintf("%s", containerConcurrencyTargetDefault)
+				desiredCm.Data["container-concurrency-target-default"] = fmt.Sprintf("%s", config.ContainerConcurrencyTargetDefault)
 			}
 
 			if cmd.Flags().Changed("container-concurrency-target-percentage") {
-				desiredCm.Data["container-concurrency-target-percentage"] = fmt.Sprintf("%s", containerConcurrencyTargetPercentage)
+				desiredCm.Data["container-concurrency-target-percentage"] = fmt.Sprintf("%s", config.ContainerConcurrencyTargetPercentage)
 			}
 
 			if cmd.Flags().Changed("stable-window") {
-				if stableWindow < as.WindowMin || stableWindow > as.WindowMax {
-					return fmt.Errorf("stable-window = %v, must be in [%v; %v] range", stableWindow,
+				if config.StableWindow < as.WindowMin || config.StableWindow > as.WindowMax {
+					return fmt.Errorf("stable-window = %v, must be in [%v; %v] range", config.StableWindow,
 						as.WindowMin, as.WindowMax)
 				}
 
-				if stableWindow.Round(time.Second) != stableWindow {
-					return fmt.Errorf("stable-window = %v, must be specified with at most second precision", stableWindow)
+				if config.StableWindow.Round(time.Second) != config.StableWindow {
+					return fmt.Errorf("stable-window = %v, must be specified with at most second precision", config.StableWindow)
 				}
 
-				fmt.Printf("debug stable-window %vs\n", stableWindow.Seconds())
-				desiredCm.Data["stable-window"] = fmt.Sprintf("%vs", stableWindow.Seconds())
+				fmt.Printf("debug stable-window %vs\n", config.StableWindow.Seconds())
+				desiredCm.Data["stable-window"] = fmt.Sprintf("%vs", config.StableWindow.Seconds())
 			}
 
 			if cmd.Flags().Changed("panic-window-percentage") {
-				desiredCm.Data["panic-window-percentage"] = panicWindowPercentage
+				desiredCm.Data["panic-window-percentage"] = config.PanicWindowPercentage
 			}
 
 			if cmd.Flags().Changed("panic-threshold-percentage") {
-				desiredCm.Data["panic-threshold-percentage"] = panicThresholdPercentage
+				desiredCm.Data["panic-threshold-percentage"] = config.PanicThresholdPercentage
 			}
 
 			if cmd.Flags().Changed("max-scale-up-rate") {
-				tmp, err := strconv.ParseFloat(maxScaleUpRate, 64)
+				tmp, err := strconv.ParseFloat(config.MaxScaleUpRate, 64)
 				if err != nil {
-					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+					return fmt.Errorf("failed to parse %v", config.MaxScaleUpRate)
 				}
 				if tmp <= 1.0 {
-					return fmt.Errorf("max-scale-up-rate = %v, must be greater than 1.0", maxScaleUpRate)
+					return fmt.Errorf("max-scale-up-rate = %v, must be greater than 1.0", config.MaxScaleUpRate)
 				}
-				desiredCm.Data["max-scale-up-rate"] = maxScaleUpRate
+				desiredCm.Data["max-scale-up-rate"] = config.MaxScaleUpRate
 			}
 
 			if cmd.Flags().Changed("max-scale-down-rate") {
-				tmp, err := strconv.ParseFloat(maxScaleDownRate, 64)
+				tmp, err := strconv.ParseFloat(config.MaxScaleDownRate, 64)
 				if err != nil {
-					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+					return fmt.Errorf("failed to parse %v", config.MaxScaleUpRate)
 				}
 				if tmp <= 1.0 {
-					return fmt.Errorf("max-scale-down-rate = %v, must be greater than 1.0", maxScaleDownRate)
+					return fmt.Errorf("max-scale-down-rate = %v, must be greater than 1.0", config.MaxScaleDownRate)
 				}
-				desiredCm.Data["max-scale-down-rate"] = maxScaleDownRate
+				desiredCm.Data["max-scale-down-rate"] = config.MaxScaleDownRate
 			}
 
 			if cmd.Flags().Changed("scale-to-zero-grace-period") {
-				if scaleToZeroGracePeriod < as.WindowMin {
-					return fmt.Errorf("scale-to-zero-grace-period must be at least %v, got %v", as.WindowMin, scaleToZeroGracePeriod)
+				if config.ScaleToZeroGracePeriod < as.WindowMin {
+					return fmt.Errorf("scale-to-zero-grace-period must be at least %v, got %v", as.WindowMin, config.ScaleToZeroGracePeriod)
 				}
 
-				desiredCm.Data["scale-to-zero-grace-period"] = fmt.Sprintf("%vs", scaleToZeroGracePeriod.Seconds())
+				desiredCm.Data["scale-to-zero-grace-period"] = fmt.Sprintf("%vs", config.ScaleToZeroGracePeriod.Seconds())
 			}
 
 			if cmd.Flags().Changed("scale-to-zero-pod-retention-period") {
-				if scaleToZeroPodRetentionPeriod < 0 {
-					return fmt.Errorf("scale-to-zero-pod-retention-period cannot be negative, was: %v", scaleToZeroPodRetentionPeriod)
+				if config.ScaleToZeroPodRetentionPeriod < 0 {
+					return fmt.Errorf("scale-to-zero-pod-retention-period cannot be negative, was: %v", config.ScaleToZeroPodRetentionPeriod)
 				}
-				desiredCm.Data["scale-to-zero-pod-retention-period"] = fmt.Sprintf("%vs", scaleToZeroPodRetentionPeriod.Seconds())
+				desiredCm.Data["scale-to-zero-pod-retention-period"] = fmt.Sprintf("%vs", config.ScaleToZeroPodRetentionPeriod.Seconds())
 			}
 
 			if cmd.Flags().Changed("target-burst-capacity") {
-				tmp, err := strconv.ParseFloat(targetBurstCapacity, 64)
+				tmp, err := strconv.ParseFloat(config.TargetBurstCapacity, 64)
 				if err != nil {
-					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+					return fmt.Errorf("failed to parse %v", config.MaxScaleUpRate)
 				}
 				if tmp < 0 && tmp != -1 {
-					return fmt.Errorf("target-burst-capacity must be either non-negative or -1 (for unlimited), got %s", targetBurstCapacity)
+					return fmt.Errorf("target-burst-capacity must be either non-negative or -1 (for unlimited), got %s", config.TargetBurstCapacity)
 				}
-				desiredCm.Data["target-burst-capacity"] = targetBurstCapacity
+				desiredCm.Data["target-burst-capacity"] = config.TargetBurstCapacity
 			}
 
 			if cmd.Flags().Changed("pod-autoscaler-class") {
-				desiredCm.Data["pod-autoscaler-class"] = podAutoscalerClass
+				desiredCm.Data["pod-autoscaler-class"] = config.PodAutoscalerClass
 			}
 
 			if cmd.Flags().Changed("activator-capacity") {
-				tmp, err := strconv.ParseFloat(activatorCapacity, 64)
+				tmp, err := strconv.ParseFloat(config.ActivatorCapacity, 64)
 				if err != nil {
-					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+					return fmt.Errorf("failed to parse %v", config.MaxScaleUpRate)
 				}
 				if tmp < 1 {
-					return fmt.Errorf("activator-capacity = %v, must be at least 1", activatorCapacity)
+					return fmt.Errorf("activator-capacity = %v, must be at least 1", config.ActivatorCapacity)
 				}
-				desiredCm.Data["activator-capacity"] = activatorCapacity
+				desiredCm.Data["activator-capacity"] = config.ActivatorCapacity
 			}
 
 			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
@@ -193,21 +212,21 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 		},
 	}
 
-	flags.AddBothBoolFlagsUnhidden(AutoscalingUpdateCommand.Flags(), &scaleToZero, "scale-to-zero", "", true,
+	flags.AddBothBoolFlagsUnhidden(AutoscalingUpdateCommand.Flags(), &config.ScaleToZero, "scale-to-zero", "", true,
 		"Enable scale-to-zero if set.")
-	AutoscalingUpdateCommand.Flags().StringVarP(&requestsPerSecondTargetDefault, "requests-per-second-target-default", "", "200", "the default target value for requests per second")
-	AutoscalingUpdateCommand.Flags().StringVarP(&containerConcurrencyTargetDefault, "container-concurrency-target-default", "", "100", "the default value of container concurrency target")
-	AutoscalingUpdateCommand.Flags().StringVarP(&containerConcurrencyTargetPercentage, "container-concurrency-target-percentage", "", "0.7", "percentage of the specified target should actually be targeted by the Autoscaler")
-	AutoscalingUpdateCommand.Flags().DurationVarP(&stableWindow, "stable-window", "", 60*time.Second, "when operating in a stable mode, the autoscaler operates on the average concurrency over the x seconds of stable window")
-	AutoscalingUpdateCommand.Flags().StringVarP(&panicWindowPercentage, "panic-window-percentage", "", "10", "The panic window is defined as a percentage of the stable window")
-	AutoscalingUpdateCommand.Flags().StringVarP(&panicThresholdPercentage, "panic-threshold-percentage", "", "200", "This threshold defines when the autoscaler will move from stable mode into panic mode")
-	AutoscalingUpdateCommand.Flags().StringVarP(&maxScaleUpRate, "max-scale-up-rate", "", "1000", "Maximum ratio of desired vs. observed pods")
-	AutoscalingUpdateCommand.Flags().StringVarP(&maxScaleDownRate, "max-scale-down-rate", "", "2", "Maximum ratio of observed vs. desired pods")
-	AutoscalingUpdateCommand.Flags().DurationVarP(&scaleToZeroGracePeriod, "scale-to-zero-grace-period", "", 30*time.Second, " the maximum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
-	AutoscalingUpdateCommand.Flags().DurationVarP(&scaleToZeroPodRetentionPeriod, "scale-to-zero-pod-retention-period", "", 0*time.Second, "the minimum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
-	AutoscalingUpdateCommand.Flags().StringVarP(&targetBurstCapacity, "target-burst-capacity", "", "200", "the desired burst capacity for the revision")
-	AutoscalingUpdateCommand.Flags().StringVarP(&podAutoscalerClass, "pod-autoscaler-class", "", "kpa.autoscaling.knative.dev", "the config of Knative autoscaling to work with either the default KPA or a CPU based metric, i.e. Horizontal Pod Autoscaler (HPA)")
-	AutoscalingUpdateCommand.Flags().StringVarP(&activatorCapacity, "activator-capacity", "", "200", "number of the concurrent requests an activator task can accept")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.RequestsPerSecondTargetDefault, "requests-per-second-target-default", "", "200", "the default target value for requests per second")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.ContainerConcurrencyTargetDefault, "container-concurrency-target-default", "", "100", "the default value of container concurrency target")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.ContainerConcurrencyTargetPercentage, "container-concurrency-target-percentage", "", "0.7", "percentage of the specified target should actually be targeted by the Autoscaler")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&config.StableWindow, "stable-window", "", 60*time.Second, "when operating in a stable mode, the autoscaler operates on the average concurrency over the x seconds of stable window")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.PanicWindowPercentage, "panic-window-percentage", "", "10", "The panic window is defined as a percentage of the stable window")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.PanicThresholdPercentage, "panic-threshold-percentage", "", "200", "This threshold defines when the autoscaler will move from stable mode into panic mode")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.MaxScaleUpRate, "max-scale-up-rate", "", "1000", "Maximum ratio of desired vs. observed pods")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.MaxScaleDownRate, "max-scale-down-rate", "", "2", "Maximum ratio of observed vs. desired pods")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&config.ScaleToZeroGracePeriod, "scale-to-zero-grace-period", "", 30*time.Second, " the maximum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&config.ScaleToZeroPodRetentionPeriod, "scale-to-zero-pod-retention-period", "", 0*time.Second, "the minimum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.TargetBurstCapacity, "target-burst-capacity", "", "200", "the desired burst capacity for the revision")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.PodAutoscalerClass, "pod-autoscaler-class", "", "kpa.autoscaling.knative.dev", "the config of Knative autoscaling to work with either the default KPA or a CPU based metric, i.e. Horizontal Pod Autoscaler (HPA)")
+	AutoscalingUpdateCommand.Flags().StringVarP(&config.ActivatorCapacity, "activator-capacity", "", "200", "number of the concurrent requests an activator task can accept")
 
 	return AutoscalingUpdateCommand
 }

--- a/pkg/command/autoscaling/update.go
+++ b/pkg/command/autoscaling/update.go
@@ -55,8 +55,8 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
   # To enable scale-to-zero
   kn admin autoscaling update --scale-to-zero
 
-  # To disable scale-to-zero
-  kn admin autoscaling update --no-scale-to-zero`,
+  # To update stable window
+  kn admin autoscaling update --stable-window 2m`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().NFlag() == 0 {
 				return errors.New("'autoscaling update' requires flag(s)")

--- a/pkg/command/autoscaling/update.go
+++ b/pkg/command/autoscaling/update.go
@@ -17,6 +17,8 @@ package autoscaling
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"time"
 
 	"knative.dev/kn-plugin-admin/pkg/command/utils"
 
@@ -28,13 +30,20 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"knative.dev/client/pkg/kn/flags"
+
+	as "knative.dev/serving/pkg/apis/autoscaling"
 )
 
 var (
-	scaleToZero       bool
-	enableScaleToZero = "enable-scale-to-zero"
-	knativeServing    = "knative-serving"
-	configAutoscaler  = "config-autoscaler"
+	scaleToZero                                                         bool
+	enableScaleToZero                                                   = "enable-scale-to-zero"
+	knativeServing                                                      = "knative-serving"
+	configAutoscaler                                                    = "config-autoscaler"
+	stableWindow, scaleToZeroGracePeriod, scaleToZeroPodRetentionPeriod time.Duration
+
+	containerConcurrencyTargetPercentage, panicWindowPercentage, panicThresholdPercentage, maxScaleUpRate,
+	maxScaleDownRate, targetBurstCapacity, activatorCapacity, requestsPerSecondTargetDefault,
+	containerConcurrencyTargetDefault, podAutoscalerClass string
 )
 
 func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
@@ -58,26 +67,127 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var desiredScaleToZero string
-			if cmd.Flags().Changed("scale-to-zero") {
-				desiredScaleToZero = "true"
-			} else if cmd.Flags().Changed("no-scale-to-zero") {
-				desiredScaleToZero = "false"
-			}
-
 			currentCm := &corev1.ConfigMap{}
 			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(configAutoscaler, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMaps: %+v", err)
 			}
 			desiredCm := currentCm.DeepCopy()
-			desiredCm.Data[enableScaleToZero] = desiredScaleToZero
+
+			if cmd.Flags().Changed("scale-to-zero") && cmd.Flags().Changed("no-scale-to-zero") {
+				return fmt.Errorf("please specify either --scale-to-zero or --no-scale-to-zero")
+			}
+
+			if cmd.Flags().Changed("scale-to-zero") {
+				desiredCm.Data[enableScaleToZero] = "true"
+			}
+
+			if cmd.Flags().Changed("no-scale-to-zero") {
+				desiredCm.Data[enableScaleToZero] = "false"
+			}
+
+			if cmd.Flags().Changed("requests-per-second-target-default") {
+				desiredCm.Data["requests-per-second-target-default"] = fmt.Sprintf("%s", requestsPerSecondTargetDefault)
+			}
+
+			if cmd.Flags().Changed("container-concurrency-target-default") {
+				desiredCm.Data["container-concurrency-target-default"] = fmt.Sprintf("%s", containerConcurrencyTargetDefault)
+			}
+
+			if cmd.Flags().Changed("container-concurrency-target-percentage") {
+				desiredCm.Data["container-concurrency-target-percentage"] = fmt.Sprintf("%s", containerConcurrencyTargetPercentage)
+			}
+
+			if cmd.Flags().Changed("stable-window") {
+				if stableWindow < as.WindowMin || stableWindow > as.WindowMax {
+					return fmt.Errorf("stable-window = %v, must be in [%v; %v] range", stableWindow,
+						as.WindowMin, as.WindowMax)
+				}
+
+				if stableWindow.Round(time.Second) != stableWindow {
+					return fmt.Errorf("stable-window = %v, must be specified with at most second precision", stableWindow)
+				}
+
+				fmt.Printf("debug stable-window %vs\n", stableWindow.Seconds())
+				desiredCm.Data["stable-window"] = fmt.Sprintf("%vs", stableWindow.Seconds())
+			}
+
+			if cmd.Flags().Changed("panic-window-percentage") {
+				desiredCm.Data["panic-window-percentage"] = panicWindowPercentage
+			}
+
+			if cmd.Flags().Changed("panic-threshold-percentage") {
+				desiredCm.Data["panic-threshold-percentage"] = panicThresholdPercentage
+			}
+
+			if cmd.Flags().Changed("max-scale-up-rate") {
+				tmp, err := strconv.ParseFloat(maxScaleUpRate, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+				}
+				if tmp <= 1.0 {
+					return fmt.Errorf("max-scale-up-rate = %v, must be greater than 1.0", maxScaleUpRate)
+				}
+				desiredCm.Data["max-scale-up-rate"] = maxScaleUpRate
+			}
+
+			if cmd.Flags().Changed("max-scale-down-rate") {
+				tmp, err := strconv.ParseFloat(maxScaleDownRate, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+				}
+				if tmp <= 1.0 {
+					return fmt.Errorf("max-scale-down-rate = %v, must be greater than 1.0", maxScaleDownRate)
+				}
+				desiredCm.Data["max-scale-down-rate"] = maxScaleDownRate
+			}
+
+			if cmd.Flags().Changed("scale-to-zero-grace-period") {
+				if scaleToZeroGracePeriod < as.WindowMin {
+					return fmt.Errorf("scale-to-zero-grace-period must be at least %v, got %v", as.WindowMin, scaleToZeroGracePeriod)
+				}
+
+				desiredCm.Data["scale-to-zero-grace-period"] = fmt.Sprintf("%vs", scaleToZeroGracePeriod.Seconds())
+			}
+
+			if cmd.Flags().Changed("scale-to-zero-pod-retention-period") {
+				if scaleToZeroPodRetentionPeriod < 0 {
+					return fmt.Errorf("scale-to-zero-pod-retention-period cannot be negative, was: %v", scaleToZeroPodRetentionPeriod)
+				}
+				desiredCm.Data["scale-to-zero-pod-retention-period"] = fmt.Sprintf("%vs", scaleToZeroPodRetentionPeriod.Seconds())
+			}
+
+			if cmd.Flags().Changed("target-burst-capacity") {
+				tmp, err := strconv.ParseFloat(targetBurstCapacity, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+				}
+				if tmp < 0 && tmp != -1 {
+					return fmt.Errorf("target-burst-capacity must be either non-negative or -1 (for unlimited), got %s", targetBurstCapacity)
+				}
+				desiredCm.Data["target-burst-capacity"] = targetBurstCapacity
+			}
+
+			if cmd.Flags().Changed("pod-autoscaler-class") {
+				desiredCm.Data["pod-autoscaler-class"] = podAutoscalerClass
+			}
+
+			if cmd.Flags().Changed("activator-capacity") {
+				tmp, err := strconv.ParseFloat(activatorCapacity, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse %v", maxScaleUpRate)
+				}
+				if tmp < 1 {
+					return fmt.Errorf("activator-capacity = %v, must be at least 1", activatorCapacity)
+				}
+				desiredCm.Data["activator-capacity"] = activatorCapacity
+			}
 
 			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configAutoscaler, knativeServing, err)
 			}
-			cmd.Printf("Updated Knative autoscaling config %s: %s\n", enableScaleToZero, desiredScaleToZero)
+			cmd.Printf("Updated Knative autoscaling config\n")
 
 			return nil
 		},
@@ -85,6 +195,19 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 
 	flags.AddBothBoolFlagsUnhidden(AutoscalingUpdateCommand.Flags(), &scaleToZero, "scale-to-zero", "", true,
 		"Enable scale-to-zero if set.")
+	AutoscalingUpdateCommand.Flags().StringVarP(&requestsPerSecondTargetDefault, "requests-per-second-target-default", "", "200", "the default target value for requests per second")
+	AutoscalingUpdateCommand.Flags().StringVarP(&containerConcurrencyTargetDefault, "container-concurrency-target-default", "", "100", "the default value of container concurrency target")
+	AutoscalingUpdateCommand.Flags().StringVarP(&containerConcurrencyTargetPercentage, "container-concurrency-target-percentage", "", "0.7", "percentage of the specified target should actually be targeted by the Autoscaler")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&stableWindow, "stable-window", "", 60*time.Second, "when operating in a stable mode, the autoscaler operates on the average concurrency over the x seconds of stable window")
+	AutoscalingUpdateCommand.Flags().StringVarP(&panicWindowPercentage, "panic-window-percentage", "", "10", "The panic window is defined as a percentage of the stable window")
+	AutoscalingUpdateCommand.Flags().StringVarP(&panicThresholdPercentage, "panic-threshold-percentage", "", "200", "This threshold defines when the autoscaler will move from stable mode into panic mode")
+	AutoscalingUpdateCommand.Flags().StringVarP(&maxScaleUpRate, "max-scale-up-rate", "", "1000", "Maximum ratio of desired vs. observed pods")
+	AutoscalingUpdateCommand.Flags().StringVarP(&maxScaleDownRate, "max-scale-down-rate", "", "2", "Maximum ratio of observed vs. desired pods")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&scaleToZeroGracePeriod, "scale-to-zero-grace-period", "", 30*time.Second, " the maximum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
+	AutoscalingUpdateCommand.Flags().DurationVarP(&scaleToZeroPodRetentionPeriod, "scale-to-zero-pod-retention-period", "", 0*time.Second, "the minimum seconds of time that the last pod will remain active after the Autoscaler has decided to scale pods to zero")
+	AutoscalingUpdateCommand.Flags().StringVarP(&targetBurstCapacity, "target-burst-capacity", "", "200", "the desired burst capacity for the revision")
+	AutoscalingUpdateCommand.Flags().StringVarP(&podAutoscalerClass, "pod-autoscaler-class", "", "kpa.autoscaling.knative.dev", "the config of Knative autoscaling to work with either the default KPA or a CPU based metric, i.e. Horizontal Pod Autoscaler (HPA)")
+	AutoscalingUpdateCommand.Flags().StringVarP(&activatorCapacity, "activator-capacity", "", "200", "number of the concurrent requests an activator task can accept")
 
 	return AutoscalingUpdateCommand
 }

--- a/pkg/command/autoscaling/update_test.go
+++ b/pkg/command/autoscaling/update_test.go
@@ -28,14 +28,15 @@ import (
 )
 
 func TestNewAsUpdateSetCommand(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configAutoscaler,
+			Namespace: knativeServing,
+		},
+		Data: make(map[string]string),
+	}
+
 	t.Run("no flags", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configAutoscaler,
-				Namespace: knativeServing,
-			},
-			Data: make(map[string]string),
-		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
 			ClientSet:          client,
@@ -48,14 +49,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	})
 
 	t.Run("operator mode should not be supported", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configAutoscaler,
-				Namespace: knativeServing,
-			},
-			Data: make(map[string]string),
-		}
 		client := k8sfake.NewSimpleClientset(cm)
+
 		p := pkg.AdminParams{
 			ClientSet:          client,
 			InstallationMethod: pkg.InstallationMethodOperator,
@@ -78,14 +73,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	})
 
 	t.Run("enable scale-to-zero successfully", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configAutoscaler,
-				Namespace: knativeServing,
-			},
-			Data: map[string]string{
-				"enable-scale-to-zero": "false",
-			},
+		cm.Data = map[string]string{
+			"enable-scale-to-zero": "false",
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
@@ -104,14 +93,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	})
 
 	t.Run("disable scale-to-zero successfully", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configAutoscaler,
-				Namespace: knativeServing,
-			},
-			Data: map[string]string{
-				"enable-scale-to-zero": "true",
-			},
+		cm.Data = map[string]string{
+			"enable-scale-to-zero": "true",
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
@@ -130,14 +113,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	})
 
 	t.Run("enable scale-to-zero but it's already enabled", func(t *testing.T) {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configAutoscaler,
-				Namespace: knativeServing,
-			},
-			Data: map[string]string{
-				"enable-scale-to-zero": "true",
-			},
+		cm.Data = map[string]string{
+			"enable-scale-to-zero": "true",
 		}
 		client := k8sfake.NewSimpleClientset(cm)
 		p := pkg.AdminParams{
@@ -153,5 +130,183 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, equality.Semantic.DeepEqual(updated, cm), "configmap should not be changed")
 
+	})
+
+	t.Run("update container-concurrency-target-percentage successfully", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"container-concurrency-target-percentage": "0.5",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--container-concurrency-target-percentage", "0.7")
+		assert.NilError(t, err)
+
+		cm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configAutoscaler, metav1.GetOptions{})
+		assert.NilError(t, err)
+		v, ok := cm.Data["container-concurrency-target-percentage"]
+		assert.Check(t, ok, "key %q should exists", "container-concurrency-target-percentage")
+		assert.Equal(t, "0.7", v, "container-concurrency-target-percentage should be 0.7")
+	})
+
+	t.Run("update stable-window successfully", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"stable-window": "60",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--stable-window", "2m")
+		assert.NilError(t, err)
+
+		cm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configAutoscaler, metav1.GetOptions{})
+		assert.NilError(t, err)
+		v, ok := cm.Data["stable-window"]
+		assert.Check(t, ok, "key %q should exists", "stable-window")
+		assert.Equal(t, "120s", v, "stable-window should be 120s")
+	})
+
+	t.Run("return error if set stable-window less than 6s", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"stable-window": "60",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--stable-window", "2s")
+		assert.ErrorContains(t, err, "stable-window = 2s, must be in", err)
+	})
+
+	t.Run("return error if set max-scale-up-rate less than 1.0", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"max-scale-up-rate": "2.0",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--max-scale-up-rate", "0.5")
+		assert.ErrorContains(t, err, "max-scale-up-rate = 0.5, must be greater than 1.0", err)
+	})
+
+	t.Run("return error if set max-scale-down-rate less than 1.0", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"max-scale-down-rate": "2.0",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--max-scale-up-rate", "0.5")
+		assert.ErrorContains(t, err, "max-scale-up-rate = 0.5, must be greater than 1.0", err)
+	})
+
+	t.Run("return error if set scale-to-zero-grace-period less than 6s", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"scale-to-zero-grace-period": "30s",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-grace-period", "1s")
+		assert.ErrorContains(t, err, "scale-to-zero-grace-period must be at least 6s, got 1s", err)
+	})
+
+	t.Run("return error if scale-to-zero-grace-period is not time duration", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"scale-to-zero-grace-period": "30s",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-grace-period", "60")
+		assert.ErrorContains(t, err, "missing unit in duration 60", err)
+	})
+
+	t.Run("update scale-to-zero-pod-retention-period successfully", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"scale-to-zero-pod-retention-period": "30s",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-pod-retention-period", "1m")
+		assert.NilError(t, err)
+
+		cm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configAutoscaler, metav1.GetOptions{})
+		assert.NilError(t, err)
+		v, ok := cm.Data["scale-to-zero-pod-retention-period"]
+		assert.Check(t, ok, "key %q should exists", "scale-to-zero-pod-retention-period")
+		assert.Equal(t, "60s", v, "scale-to-zero-pod-retention-period should be 60s")
+	})
+
+	t.Run("return error target-burst-capacity if set to -5", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"target-burst-capacity": "-1",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--target-burst-capacity", "-5")
+		assert.ErrorContains(t, err, "target-burst-capacity must be either non-negative or -1 (for unlimited), got -5", err)
+	})
+
+	t.Run("update pod-autoscaler-class successfully", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"pod-autoscaler-class": "old.class",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--pod-autoscaler-class", "new.class")
+		assert.NilError(t, err)
+
+		cm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configAutoscaler, metav1.GetOptions{})
+		assert.NilError(t, err)
+		v, ok := cm.Data["pod-autoscaler-class"]
+		assert.Check(t, ok, "key %q should exists", "pod-autoscaler-class")
+		assert.Equal(t, "new.class", v, "pod-autoscaler-classshould be new.class")
+	})
+
+	t.Run("return error if set activator-capacity to less than 1", func(t *testing.T) {
+		cm.Data = map[string]string{
+			"activator-capacity": "2",
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet:          client,
+			InstallationMethod: pkg.InstallationMethodStandalone,
+		}
+		cmd := NewAutoscalingUpdateCommand(&p)
+		_, err := testutil.ExecuteCommand(cmd, "--activator-capacity", "0.5")
+		assert.ErrorContains(t, err, "activator-capacity = 0.5, must be at least 1", err)
 	})
 }

--- a/pkg/command/registry/list.go
+++ b/pkg/command/registry/list.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
-	"knative.dev/kn-plugin-admin/pkg"
 	"knative.dev/client/pkg/kn/commands"
 	"knative.dev/client/pkg/kn/commands/flags"
+	"knative.dev/kn-plugin-admin/pkg"
 )
 
 // NewRegistryListCommand represents the list command

--- a/pkg/command/registry/list_test.go
+++ b/pkg/command/registry/list_test.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
+	"knative.dev/client/pkg/util"
 	"knative.dev/kn-plugin-admin/pkg"
 	"knative.dev/kn-plugin-admin/pkg/testutil"
-	"knative.dev/client/pkg/util"
 )
 
 var (

--- a/test/e2e/kn_admin_test.go
+++ b/test/e2e/kn_admin_test.go
@@ -86,6 +86,11 @@ func TestKnAdminPlugin(t *testing.T) {
 	err = e2eTest.backupConfigMap("config-observability")
 	assert.NilError(t, err)
 
+	t.Log("test kn admin autoscaling subcommand")
+	e2eTest.knAdminAutoscaling(t, r)
+	err = e2eTest.backupConfigMap("config-autoscaler")
+	assert.NilError(t, err)
+
 	t.Log("test kn admin profiling subcommand")
 	e2eTest.knAdminProfiling(t, r)
 	err = e2eTest.restoreConfigMap("config-observability")
@@ -134,6 +139,15 @@ func (et *e2eTest) knAdminDomain(t *testing.T, r *test.KnRunResultCollector) {
 	out = et.kn.Run(pluginName, "domain", "set", "--custom-domain", domain, "--selector", "app=v1")
 	r.AssertNoError(out)
 	out = et.kn.Run(pluginName, "domain", "unset", "--custom-domain", domain)
+	r.AssertNoError(out)
+}
+
+func (et *e2eTest) knAdminAutoscaling(t *testing.T, r *test.KnRunResultCollector) {
+	out := et.kn.Run(pluginName, "autoscaling", "update", "--max-scale-up-rate", "2.5")
+	r.AssertNoError(out)
+	out = et.kn.Run(pluginName, "autoscaling", "update", "--stable-window", "2m", "--activator-capacity", "300")
+	r.AssertNoError(out)
+	out = et.kn.Run(pluginName, "autoscaling", "update", "--scale-to-zero")
 	r.AssertNoError(out)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -583,6 +583,7 @@ knative.dev/pkg/profiling
 knative.dev/pkg/ptr
 knative.dev/pkg/tracker
 # knative.dev/serving v0.14.0
+## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
 knative.dev/serving/pkg/apis/config


### PR DESCRIPTION
 The default setting will be consistent with values in [knative doc](https://knative.dev/development/serving/autoscaling/autoscaling-concepts/)

- [x] Stable-window xx
- [x] panic-window-percentage xx
- [x] max-scale-up-rate xx
- [x] container-concurrency-target-default xx
- [x] container-concurrency-target-percentage xx
- [x] requests-per-second-target-default xx
- [x] target-burst-capacity
- [x] panic-threshold-percentage
- [x] max-scale-down-rate
- [x] scale-to-zero-grace-period
- [x] scale-to-zero-pod-retention-period
- [x] pod-autoscaler-class
- [x] activator-capacity
