### PR TITLE
Update github workflow go test to setup go 1.14

### DIFF
--- a/.github/workflows/knative-go-test.yaml
+++ b/.github/workflows/knative-go-test.yaml
@@ -31,7 +31,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Since unit tests break for go 1.15
