### PR TITLE
Add CODE_OF_CONDUCT.md and OWNER_ALIASES

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Contributor Covenant Code of Conduct
+
+Please see the Knative Community
+[Contributor Covenant Code of Conduct](https://www.knative.dev/contributing/code-of-conduct/).

--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,4 @@ approvers:
 - rhuss
 - maximilien
 - navidshaikh
-# Also including TOC members as backup:
-- evankanderson
-- grantr
-- markusthoemmes
-- mattmoor
-- tcnghia
+- technical-oversight-committee

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+aliases:
+  technical-oversight-committee:
+    - evankanderson
+    - grantr
+    - markusthoemmes
+    - mattmoor
+    - tcnghia


### PR DESCRIPTION
# Changes
replace toc members in OWNERS file with their alias technical-oversight-committee

as done in https://github.com/knative-sandbox/kn-plugin-source-kafka/pull/15