### PR TITLE
Avoid to print runtime error if kubectl context is not set

### DIFF
--- a/core/root.go
+++ b/core/root.go
@@ -32,7 +32,7 @@ import (
 var cfgFile string
 
 // NewAdminCommand represents the base command when called without any subcommands
-func NewAdminCommand(params ...pkg.AdminParams) *cobra.Command {
+func NewAdminCommand() *cobra.Command {
 	p := &pkg.AdminParams{}
 	p.Initialize()
 

--- a/pkg/command/autoscaling/list.go
+++ b/pkg/command/autoscaling/list.go
@@ -136,8 +136,13 @@ func NewAutoscalingListCommand(p *pkg.AdminParams) *cobra.Command {
   kn admin autoscaling list`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configAutoscaler, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configAutoscaler, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMaps: %+v", err)
 			}

--- a/pkg/command/autoscaling/list_test.go
+++ b/pkg/command/autoscaling/list_test.go
@@ -23,9 +23,7 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/client/pkg/util"
-	"knative.dev/kn-plugin-admin/pkg"
 	"knative.dev/kn-plugin-admin/pkg/testutil"
 	"knative.dev/serving/pkg/autoscaler/config"
 )
@@ -82,9 +80,10 @@ func TestAutoscalingListDefaultValues(t *testing.T) {
 			},
 			Data: map[string]string{},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{ClientSet: client}
-		cmd := NewAutoscalingListCommand(&p)
+
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewAutoscalingListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd)
 		assert.NilError(t, err)
 		checkListOutput(t, cm.Data, output, false)
@@ -104,9 +103,9 @@ func TestAutoscalingListCommand(t *testing.T) {
 				"max-scale-up-rate":       "100",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{ClientSet: client}
-		cmd := NewAutoscalingListCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewAutoscalingListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd)
 		assert.NilError(t, err)
 		checkListOutput(t, cm.Data, output, false)
@@ -124,9 +123,9 @@ func TestAutoscalingListCommandNoHeader(t *testing.T) {
 				"enable-scale-to-zero": "true",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{ClientSet: client}
-		cmd := NewAutoscalingListCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewAutoscalingListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd, "--no-headers")
 		assert.NilError(t, err)
 		checkListOutput(t, cm.Data, output, true)

--- a/pkg/command/autoscaling/list_test.go
+++ b/pkg/command/autoscaling/list_test.go
@@ -71,6 +71,15 @@ func TestDescribesDuration(t *testing.T) {
 	assert.Equal(t, t3.String(), describeDuration(t3))
 }
 
+func TestAutoscalingListWithoutKubeContext(t *testing.T) {
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		cmd := NewAutoscalingListCommand(p)
+		_, err := testutil.ExecuteCommand(cmd)
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+}
+
 func TestAutoscalingListDefaultValues(t *testing.T) {
 	t.Run("no flags", func(t *testing.T) {
 		cm := &corev1.ConfigMap{

--- a/pkg/command/autoscaling/update.go
+++ b/pkg/command/autoscaling/update.go
@@ -87,8 +87,13 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configAutoscaler, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configAutoscaler, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMaps: %+v", err)
 			}
@@ -203,7 +208,7 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 				desiredCm.Data["activator-capacity"] = config.ActivatorCapacity
 			}
 
-			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
+			err = utils.UpdateConfigMap(client, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configAutoscaler, knativeServing, err)
 			}

--- a/pkg/command/autoscaling/update_test.go
+++ b/pkg/command/autoscaling/update_test.go
@@ -36,6 +36,14 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		Data: make(map[string]string),
 	}
 
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("no flags", func(t *testing.T) {
 		p, client := testutil.NewTestAdminParams(cm)
 		assert.Check(t, client != nil)

--- a/pkg/command/autoscaling/update_test.go
+++ b/pkg/command/autoscaling/update_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/kn-plugin-admin/pkg"
 
 	"knative.dev/kn-plugin-admin/pkg/testutil"
@@ -38,37 +37,30 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	}
 
 	t.Run("no flags", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd)
 		assert.ErrorContains(t, err, "'autoscaling update' requires flag(s)", err)
 	})
 
 	t.Run("operator mode should not be supported", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset(cm)
-
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodOperator,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodOperator
+		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.ErrorContains(t, err, "Knative managed by operator is not supported yet", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.ErrorContains(t, err, "failed to get ConfigMaps", err)
 	})
@@ -77,12 +69,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"enable-scale-to-zero": "false",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.NilError(t, err)
 
@@ -97,12 +87,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"enable-scale-to-zero": "true",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--no-scale-to-zero")
 		assert.NilError(t, err)
 
@@ -117,12 +105,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"enable-scale-to-zero": "true",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.NilError(t, err)
@@ -137,12 +123,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"container-concurrency-target-percentage": "0.5",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--container-concurrency-target-percentage", "0.7")
 		assert.NilError(t, err)
 
@@ -157,12 +141,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"stable-window": "60",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--stable-window", "2m")
 		assert.NilError(t, err)
 
@@ -177,12 +159,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"stable-window": "60",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--stable-window", "2s")
 		assert.ErrorContains(t, err, "stable-window = 2s, must be in", err)
 	})
@@ -191,12 +171,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"max-scale-up-rate": "2.0",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--max-scale-up-rate", "0.5")
 		assert.ErrorContains(t, err, "max-scale-up-rate = 0.5, must be greater than 1.0", err)
 	})
@@ -205,12 +183,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"max-scale-down-rate": "2.0",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--max-scale-up-rate", "0.5")
 		assert.ErrorContains(t, err, "max-scale-up-rate = 0.5, must be greater than 1.0", err)
 	})
@@ -219,12 +195,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"scale-to-zero-grace-period": "30s",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-grace-period", "1s")
 		assert.ErrorContains(t, err, "scale-to-zero-grace-period must be at least 6s, got 1s", err)
 	})
@@ -233,12 +207,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"scale-to-zero-grace-period": "30s",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-grace-period", "60")
 		assert.ErrorContains(t, err, "missing unit in duration 60", err)
 	})
@@ -247,12 +219,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"scale-to-zero-pod-retention-period": "30s",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero-pod-retention-period", "1m")
 		assert.NilError(t, err)
 
@@ -267,12 +237,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"target-burst-capacity": "-1",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--target-burst-capacity", "-5")
 		assert.ErrorContains(t, err, "target-burst-capacity must be either non-negative or -1 (for unlimited), got -5", err)
 	})
@@ -281,12 +249,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"pod-autoscaler-class": "old.class",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--pod-autoscaler-class", "new.class")
 		assert.NilError(t, err)
 
@@ -301,12 +267,10 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 		cm.Data = map[string]string{
 			"activator-capacity": "2",
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--activator-capacity", "0.5")
 		assert.ErrorContains(t, err, "activator-capacity = 0.5, must be at least 1", err)
 	})

--- a/pkg/command/domain/list.go
+++ b/pkg/command/domain/list.go
@@ -37,7 +37,12 @@ func NewDomainListCommand(p *pkg.AdminParams) *cobra.Command {
   kn admin domain list`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			domainCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
+			domainCm, err := client.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}

--- a/pkg/command/domain/list_test.go
+++ b/pkg/command/domain/list_test.go
@@ -21,9 +21,7 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/client/pkg/util"
-	"knative.dev/kn-plugin-admin/pkg"
 
 	"knative.dev/kn-plugin-admin/pkg/testutil"
 )
@@ -37,11 +35,9 @@ func TestDomainListEmpty(t *testing.T) {
 			},
 			Data: map[string]string{},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainListCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewDomainListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd)
 		assert.NilError(t, err)
 		rowsOfOutput := strings.Split(output, "\n")
@@ -63,11 +59,9 @@ func TestDomainListCommand(t *testing.T) {
 				"test2.domain":  "selector:\n  app: helloworld\n",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainListCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewDomainListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd)
 		assert.NilError(t, err)
 		rowsOfOutput := strings.Split(output, "\n")
@@ -92,11 +86,9 @@ func TestDomainListCommandNoHeader(t *testing.T) {
 				"test2.domain": "selector:\n  app: helloworld\n",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainListCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		cmd := NewDomainListCommand(p)
 		output, err := testutil.ExecuteCommand(cmd, "--no-headers")
 		assert.NilError(t, err)
 		rowsOfOutput := strings.Split(output, "\n")

--- a/pkg/command/domain/list_test.go
+++ b/pkg/command/domain/list_test.go
@@ -26,6 +26,15 @@ import (
 	"knative.dev/kn-plugin-admin/pkg/testutil"
 )
 
+func TestDomainListWithoutKubeContext(t *testing.T) {
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		cmd := NewDomainListCommand(p)
+		_, err := testutil.ExecuteCommand(cmd)
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+}
+
 func TestDomainListEmpty(t *testing.T) {
 	t.Run("list domain", func(t *testing.T) {
 		cm := &corev1.ConfigMap{

--- a/pkg/command/domain/set.go
+++ b/pkg/command/domain/set.go
@@ -58,8 +58,13 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}
@@ -91,7 +96,7 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 
 			desiredCm.Data[domain] = value
 
-			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
+			err = utils.UpdateConfigMap(client, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}

--- a/pkg/command/domain/set_test.go
+++ b/pkg/command/domain/set_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/kn-plugin-admin/pkg"
 
 	"knative.dev/kn-plugin-admin/pkg/testutil"
@@ -55,12 +54,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
 		assert.ErrorContains(t, err, "requires the route name", err)
@@ -74,24 +71,20 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodOperator,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodOperator
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.ErrorContains(t, err, "Knative managed by operator is not supported yet", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.ErrorContains(t, err, "failed to get ConfigMap", err)
 	})
@@ -104,12 +97,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.NilError(t, err)
 
@@ -132,12 +123,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"test.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.NilError(t, err)
@@ -158,12 +147,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Set knative route domain \"test.domain\""), "expected update information in standard output")
@@ -187,12 +174,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 
 		o, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain", "--selector", "app=test")
 		assert.NilError(t, err)
@@ -225,12 +210,10 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain", "--selector", "app")
 		assert.ErrorContains(t, err, "expecting the selector format 'name=value', found 'app'", err)

--- a/pkg/command/domain/set_test.go
+++ b/pkg/command/domain/set_test.go
@@ -46,6 +46,14 @@ func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 
 func TestNewDomainSetCommand(t *testing.T) {
 
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainSetCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("incompleted args", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/command/domain/unset.go
+++ b/pkg/command/domain/unset.go
@@ -43,8 +43,13 @@ func NewDomainUnSetCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(context.TODO(), configDomain, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get configmaps: %+v", err)
 			}
@@ -58,7 +63,7 @@ func NewDomainUnSetCommand(p *pkg.AdminParams) *cobra.Command {
 				return fmt.Errorf("Knative route domain %s not found\n", domain)
 			}
 
-			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
+			err = utils.UpdateConfigMap(client, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}

--- a/pkg/command/domain/unset_test.go
+++ b/pkg/command/domain/unset_test.go
@@ -21,7 +21,6 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/kn-plugin-admin/pkg"
 
 	"knative.dev/kn-plugin-admin/pkg/testutil"
@@ -37,24 +36,20 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
 		assert.ErrorContains(t, err, "requires the route name", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainUnSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
 		assert.ErrorContains(t, err, "failed to get configmaps", err)
 	})
@@ -69,12 +64,10 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 				"test.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "not-test.domain")
 		assert.ErrorContains(t, err, "Knative route domain not-test.domain not found", err)
@@ -91,12 +84,10 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 				"test2.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet:          client,
-			InstallationMethod: pkg.InstallationMethodStandalone,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainUnSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test1.domain")
 		assert.NilError(t, err)
 

--- a/pkg/command/domain/unset_test.go
+++ b/pkg/command/domain/unset_test.go
@@ -28,6 +28,14 @@ import (
 
 func TestNewDomainUnSetCommand(t *testing.T) {
 
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewDomainUnSetCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "test.domain")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("incompleted args", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/command/profiling/profiling.go
+++ b/pkg/command/profiling/profiling.go
@@ -155,9 +155,9 @@ func NewProfilingCommand(p *pkg.AdminParams) *cobra.Command {
 			if flags.NFlag() < 1 {
 				return nil
 			} else if flags.Changed("enable") {
-				return configProfiling(p.ClientSet, cmd, true)
+				return configProfiling(p, cmd, true)
 			} else if flags.Changed("disable") {
-				return configProfiling(p.ClientSet, cmd, false)
+				return configProfiling(p, cmd, false)
 			} else {
 				return downloadProfileData(p, cmd, &pflags)
 			}
@@ -182,9 +182,14 @@ func NewProfilingCommand(p *pkg.AdminParams) *cobra.Command {
 }
 
 // configProfiling enables or disables knative profiling
-func configProfiling(c kubernetes.Interface, cmd *cobra.Command, enable bool) error {
+func configProfiling(p *pkg.AdminParams, cmd *cobra.Command, enable bool) error {
+	client, err := p.NewKubeClient()
+	if err != nil {
+		return err
+	}
+
 	currentCm := &corev1.ConfigMap{}
-	currentCm, err := c.CoreV1().ConfigMaps(knNamespace).Get(context.TODO(), obsConfigMap, metav1.GetOptions{})
+	currentCm, err = client.CoreV1().ConfigMaps(knNamespace).Get(context.TODO(), obsConfigMap, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get ConfigMap %s in namespace %s: %+v", obsConfigMap, knNamespace, err)
 	}
@@ -196,7 +201,7 @@ func configProfiling(c kubernetes.Interface, cmd *cobra.Command, enable bool) er
 		desiredCm.Data["profiling.enable"] = "false"
 	}
 
-	err = utils.UpdateConfigMap(c, desiredCm)
+	err = utils.UpdateConfigMap(client, desiredCm)
 	if err != nil {
 		return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", obsConfigMap, knNamespace, err)
 	}
@@ -282,6 +287,11 @@ func durationDescription(seconds int64) string {
 
 // downloadProfileData downloads profile data by given profile type
 func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profilingFlags) error {
+	client, err := p.NewKubeClient()
+	if err != nil {
+		return err
+	}
+
 	// check profile types
 	profileTypes := map[string]profileTypeOption{}
 	if pflags.allProfiles {
@@ -357,7 +367,6 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 	}
 
 	// check --save-to path
-	var err error
 	if pflags.saveTo == "" {
 		pflags.saveTo, err = os.Getwd()
 		if err != nil {
@@ -376,7 +385,7 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 	}
 
 	// check if profiling is enabled, if not, print message to ask user enable it first
-	enabled, err := isProfilingEnabled(p.ClientSet)
+	enabled, err := isProfilingEnabled(client)
 	if err != nil {
 		return err
 	}
@@ -385,13 +394,13 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 	}
 
 	// try to find target as a knative component name
-	pods, err := p.ClientSet.CoreV1().Pods(knNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=" + pflags.target})
+	pods, err := client.CoreV1().Pods(knNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=" + pflags.target})
 	if err != nil {
 		return err
 	}
 	// if no pod found, try to find target as a pod name in knative namespace
 	if len(pods.Items) < 1 {
-		pods, err = p.ClientSet.CoreV1().Pods(knNamespace).List(context.TODO(), metav1.ListOptions{})
+		pods, err = client.CoreV1().Pods(knNamespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/command/profiling/profiling_test.go
+++ b/pkg/command/profiling/profiling_test.go
@@ -83,6 +83,14 @@ func removeProfileDataFiles(nameFilter string) {
 
 // TestNewProfilingCommand tests the profiling command
 func TestNewProfilingCommand(t *testing.T) {
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		p.InstallationMethod = pkg.InstallationMethodStandalone
+		cmd := NewProfilingCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--enable")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("runs profiling without args", func(t *testing.T) {
 		out, err := testutil.ExecuteCommand(newProfilingCommand(), "", "")
 		assert.NilError(t, err)

--- a/pkg/command/profiling/profiling_test.go
+++ b/pkg/command/profiling/profiling_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8sfakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -39,14 +40,22 @@ import (
 
 func newProfilingCommand() *cobra.Command {
 	client := k8sfake.NewSimpleClientset(&corev1.ConfigMap{})
-	p := pkg.AdminParams{ClientSet: client}
-	return NewProfilingCommand(&p)
+	p := &pkg.AdminParams{
+		NewKubeClient: func() (kubernetes.Interface, error) {
+			return client, nil
+		},
+	}
+	return NewProfilingCommand(p)
 }
 
 func newProfilingCommandWith(cm *corev1.ConfigMap) (*cobra.Command, *k8sfake.Clientset) {
 	client := k8sfake.NewSimpleClientset(cm)
-	p := pkg.AdminParams{ClientSet: client}
-	return NewProfilingCommand(&p), client
+	p := &pkg.AdminParams{
+		NewKubeClient: func() (kubernetes.Interface, error) {
+			return client, nil
+		},
+	}
+	return NewProfilingCommand(p), client
 }
 
 type fakeDownloader struct {

--- a/pkg/command/registry/add.go
+++ b/pkg/command/registry/add.go
@@ -103,12 +103,17 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 				Data: secretData,
 			}
 
-			secret, err = p.ClientSet.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
+			secret, err = client.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create secret in namespace '%s': %v", namespace, err)
 			}
 
-			sa, err := p.ClientSet.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), registryFlags.ServiceAccount, metav1.GetOptions{})
+			sa, err := client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), registryFlags.ServiceAccount, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get serviceaccount '%s' in namespace '%s': %v", registryFlags.ServiceAccount, namespace, err)
 			}
@@ -117,7 +122,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 				Name: secret.Name,
 			})
 
-			_, err = p.ClientSet.CoreV1().ServiceAccounts(namespace).Update(context.TODO(), desiredSa, metav1.UpdateOptions{})
+			_, err = client.CoreV1().ServiceAccounts(namespace).Update(context.TODO(), desiredSa, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to add registry secret in serviceaccount '%s' in namespace '%s': %v", registryFlags.ServiceAccount, namespace, err)
 			}
@@ -129,7 +134,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 			}
 
 			secret.ObjectMeta.Labels = updateLabel
-			_, err = p.ClientSet.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+			_, err = client.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to update secret label in namespace '%s': %v", namespace, err)
 			}

--- a/pkg/command/registry/add_test.go
+++ b/pkg/command/registry/add_test.go
@@ -30,17 +30,14 @@ import (
 	"knative.dev/kn-plugin-admin/pkg/testutil"
 
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestNewRegistryAddCommand(t *testing.T) {
 
 	t.Run("incompleted args for registry add", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryAddCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -54,11 +51,8 @@ func TestNewRegistryAddCommand(t *testing.T) {
 	})
 
 	t.Run("missing default serviceaccount", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryAddCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "test", "--server", "docker.io")
 		assert.ErrorContains(t, err, "failed to get serviceaccount")
@@ -71,13 +65,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				Namespace: "default",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa)
+
+		p, client := testutil.NewTestAdminParams(&sa)
+		assert.Check(t, client != nil)
 		client.PrependReactor("create", "secrets", generateNameReactor)
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
 		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "test", "--server", "docker.io")
 		assert.NilError(t, err)
@@ -124,13 +115,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				Namespace: "custom-namespace",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&ns, &sa)
+
+		p, client := testutil.NewTestAdminParams(&ns, &sa)
+		assert.Check(t, client != nil)
 		client.PrependReactor("create", "secrets", generateNameReactor)
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
 		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "add", "--username", "user", "--password", "test", "--server", "docker.io", "--namespace", "custom-namespace", "--serviceaccount", "custom-serviceaccount")
 		assert.NilError(t, err)
@@ -178,13 +166,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				},
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa)
+
+		p, client := testutil.NewTestAdminParams(&sa)
+		assert.Check(t, client != nil)
 		client.PrependReactor("create", "secrets", generateNameReactor)
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
 		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "test", "--server", "docker.io")
 		assert.NilError(t, err)

--- a/pkg/command/registry/add_test.go
+++ b/pkg/command/registry/add_test.go
@@ -35,6 +35,13 @@ import (
 
 func TestNewRegistryAddCommand(t *testing.T) {
 
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		cmd := NewRegistryAddCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "test", "--server", "docker.io")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("incompleted args for registry add", func(t *testing.T) {
 		p, client := testutil.NewTestAdminParams()
 		assert.Check(t, client != nil)

--- a/pkg/command/registry/list.go
+++ b/pkg/command/registry/list.go
@@ -51,14 +51,19 @@ func NewRegistryListCommand(p *pkg.AdminParams) *cobra.Command {
 				return fmt.Errorf("cannot specifiy service account with empty namespace")
 			}
 
-			namespacesList, err := searchNamespace(p.ClientSet, namespace)
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
+			namespacesList, err := searchNamespace(client, namespace)
 			if err != nil {
 				return fmt.Errorf("failed to search specified namespaces: %v", err)
 			}
 
 			secretList := &corev1.SecretList{}
 			for _, ns := range namespacesList.Items {
-				err = addSecrets(p.ClientSet, ns.Name, serviceaccount, secretList)
+				err = addSecrets(client, ns.Name, serviceaccount, secretList)
 			}
 
 			// empty namespace indicates all-namespaces flag is specified

--- a/pkg/command/registry/list_test.go
+++ b/pkg/command/registry/list_test.go
@@ -63,12 +63,8 @@ var (
 
 func TestNewRegistryListCommand(t *testing.T) {
 	t.Run("list registries with service account only but no namespace specified", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryListCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--serviceaccount", "fakeServiceAccount")
@@ -79,7 +75,9 @@ func TestNewRegistryListCommand(t *testing.T) {
 		client := fakeRegistry()
 
 		p := &pkg.AdminParams{
-			ClientSet: client,
+			NewKubeClient: func() (kubernetes.Interface, error) {
+				return client, nil
+			},
 		}
 
 		cmd := NewRegistryListCommand(p)
@@ -97,7 +95,9 @@ func TestNewRegistryListCommand(t *testing.T) {
 		client := fakeRegistry()
 
 		p := &pkg.AdminParams{
-			ClientSet: client,
+			NewKubeClient: func() (kubernetes.Interface, error) {
+				return client, nil
+			},
 		}
 
 		cmd := NewRegistryListCommand(p)
@@ -116,7 +116,9 @@ func TestNewRegistryListCommand(t *testing.T) {
 		client := fakeRegistry()
 
 		p := &pkg.AdminParams{
-			ClientSet: client,
+			NewKubeClient: func() (kubernetes.Interface, error) {
+				return client, nil
+			},
 		}
 
 		cmd := NewRegistryListCommand(p)

--- a/pkg/command/registry/list_test.go
+++ b/pkg/command/registry/list_test.go
@@ -62,6 +62,13 @@ var (
 )
 
 func TestNewRegistryListCommand(t *testing.T) {
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		cmd := NewRegistryListCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--serviceaccount", fakeServiceAccount, "--namespace", fakeNamespace)
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("list registries with service account only but no namespace specified", func(t *testing.T) {
 		p, client := testutil.NewTestAdminParams()
 		assert.Check(t, client != nil)

--- a/pkg/command/registry/registry_test.go
+++ b/pkg/command/registry/registry_test.go
@@ -17,14 +17,15 @@ package registry
 import (
 	"testing"
 
-	"knative.dev/kn-plugin-admin/pkg"
+	"knative.dev/kn-plugin-admin/pkg/testutil"
 
 	"gotest.tools/assert"
 )
 
 func TestNewPrivateRegistryCmd(t *testing.T) {
-	p := pkg.AdminParams{}
-	cmd := NewPrivateRegistryCmd(&p)
+	p, client := testutil.NewTestAdminParams()
+	assert.Check(t, client != nil)
+	cmd := NewPrivateRegistryCmd(p)
 	assert.Check(t, cmd.HasSubCommands(), "cmd registry should have subcommands")
 	assert.Equal(t, 4, len(cmd.Commands()), "registry command should have 4 subcommands")
 

--- a/pkg/command/registry/remove_test.go
+++ b/pkg/command/registry/remove_test.go
@@ -30,6 +30,13 @@ import (
 )
 
 func TestNewRegistryRmCommand(t *testing.T) {
+	t.Run("kubectl context is not set", func(t *testing.T) {
+		p := testutil.NewTestAdminWithoutKubeConfig()
+		cmd := NewRegistryRmCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
+		assert.Error(t, err, testutil.ErrNoKubeConfiguration)
+	})
+
 	t.Run("incompleted args for registry remove", func(t *testing.T) {
 		p, client := testutil.NewTestAdminParams()
 		assert.Check(t, client != nil)

--- a/pkg/command/registry/remove_test.go
+++ b/pkg/command/registry/remove_test.go
@@ -27,18 +27,12 @@ import (
 
 	"knative.dev/kn-plugin-admin/pkg"
 	"knative.dev/kn-plugin-admin/pkg/testutil"
-
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewRegistryRmCommand(t *testing.T) {
 	t.Run("incompleted args for registry remove", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -49,11 +43,8 @@ func TestNewRegistryRmCommand(t *testing.T) {
 	})
 
 	t.Run("registry not found", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
@@ -98,12 +89,9 @@ func TestNewRegistryRmCommand(t *testing.T) {
 				".dockerconfigjson": j,
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa, &secret)
 
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams(&sa, &secret)
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
@@ -167,12 +155,9 @@ func TestNewRegistryRmCommand(t *testing.T) {
 				".dockerconfigjson": j,
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&ns, &sa, &secret)
 
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams(&ns, &sa, &secret)
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io", "--namespace", "custom-namespace", "--serviceaccount", "custom-serviceaccount")
 		assert.NilError(t, err)

--- a/pkg/testutil/command.go
+++ b/pkg/testutil/command.go
@@ -16,6 +16,7 @@ package testutil
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +24,10 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"knative.dev/kn-plugin-admin/pkg"
+)
+
+const (
+	ErrNoKubeConfiguration = "invalid configuration: no configuration has been provided"
 )
 
 // ExecuteCommandC execute cobra.command and catch the output
@@ -41,7 +46,7 @@ func ExecuteCommand(root *cobra.Command, args ...string) (output string, err err
 	return o, err
 }
 
-// NewTestAdminParams creates an AdminParams and kubenetes clientset for testing
+// NewTestAdminParams creates an AdminParams and kubernetes clientset for testing
 func NewTestAdminParams(objects ...runtime.Object) (*pkg.AdminParams, *k8sfake.Clientset) {
 	client := k8sfake.NewSimpleClientset(objects...)
 	return &pkg.AdminParams{
@@ -49,4 +54,13 @@ func NewTestAdminParams(objects ...runtime.Object) (*pkg.AdminParams, *k8sfake.C
 			return client, nil
 		},
 	}, client
+}
+
+// NewTestAdminWithoutKubeConfig creates an AdminParams without kube config when create kubernetes clientset
+func NewTestAdminWithoutKubeConfig() *pkg.AdminParams {
+	return &pkg.AdminParams{
+		NewKubeClient: func() (kubernetes.Interface, error) {
+			return nil, errors.New(ErrNoKubeConfiguration)
+		},
+	}
 }

--- a/pkg/testutil/command.go
+++ b/pkg/testutil/command.go
@@ -18,6 +18,11 @@ import (
 	"bytes"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"knative.dev/kn-plugin-admin/pkg"
 )
 
 // ExecuteCommandC execute cobra.command and catch the output
@@ -34,4 +39,14 @@ func ExecuteCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 func ExecuteCommand(root *cobra.Command, args ...string) (output string, err error) {
 	_, o, err := ExecuteCommandC(root, args...)
 	return o, err
+}
+
+// NewTestAdminParams creates an AdminParams and kubenetes clientset for testing
+func NewTestAdminParams(objects ...runtime.Object) (*pkg.AdminParams, *k8sfake.Clientset) {
+	client := k8sfake.NewSimpleClientset(objects...)
+	return &pkg.AdminParams{
+		NewKubeClient: func() (kubernetes.Interface, error) {
+			return client, nil
+		},
+	}, client
 }

--- a/pkg/types_test.go
+++ b/pkg/types_test.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -44,7 +45,9 @@ func TestAdminParams_installationMethod(t *testing.T) {
 		client := k8sfake.NewSimpleClientset(domainCM)
 
 		params := &AdminParams{
-			ClientSet: client,
+			NewKubeClient: func() (kubernetes.Interface, error) {
+				return client, nil
+			},
 		}
 		got, err := params.installationMethod()
 		if err != nil {
@@ -66,7 +69,9 @@ func TestAdminParams_installationMethod(t *testing.T) {
 		client := k8sfake.NewSimpleClientset(domainCM)
 
 		params := &AdminParams{
-			ClientSet: client,
+			NewKubeClient: func() (kubernetes.Interface, error) {
+				return client, nil
+			},
 		}
 		got, err := params.installationMethod()
 		if err != nil {

--- a/test/e2e/kn_admin_test.go
+++ b/test/e2e/kn_admin_test.go
@@ -106,6 +106,47 @@ func TestKnAdminPlugin(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestKnAdminPluginWithNoKubectlContext(t *testing.T) {
+	e2eTest := newE2ETest(t)
+	assert.Assert(t, e2eTest != nil)
+	defer func() {
+		assert.NilError(t, e2eTest.it.KnTest().Teardown())
+	}()
+
+	// get current context
+	currentCtx, err := e2eTest.kubectl.Run("config", "current-context")
+	assert.NilError(t, err)
+	assert.Check(t, currentCtx != "", "kubectl current context should not be empty")
+	currentCtx = strings.Trim(currentCtx, "\n")
+
+	// restore current context before exiting
+	defer func() {
+		_, err := e2eTest.kubectl.Run("config", "set", "current-context", currentCtx)
+		assert.NilError(t, err)
+		t.Log("kubectl current context is set to: " + currentCtx)
+	}()
+
+	// unset current context
+	_, err = e2eTest.kubectl.Run("config", "unset", "current-context")
+	assert.NilError(t, err)
+
+	// prepare admin plugin
+	r := test.NewKnRunResultCollector(t, e2eTest.it.KnTest())
+	defer r.DumpIfFailed()
+
+	// install admin plugin
+	assert.NilError(t, e2eTest.it.KnPlugin().Install())
+
+	// run kn admin profiling to make sure no runtime panic
+	t.Log("run kn admin profiling subcommand with no kubectl context")
+	out := e2eTest.kn.Run(pluginName, "profiling", "--heap", "-t", "activator")
+	r.AssertError(out)
+	assert.Check(t, strings.Contains(out.Stdout, "Error: invalid configuration: no configuration has been provided"))
+
+	// uninstall admin plugin
+	assert.NilError(t, e2eTest.it.KnPlugin().Uninstall())
+}
+
 func (et *e2eTest) backupConfigMap(cm string) error {
 	data, err := et.kubectl.Run("get", "configmap", cm, "-oyaml")
 	if err != nil {


### PR DESCRIPTION
This PR is used to address issue #32, following `kn/client`, we will delay creating kubenets client interface till subcommand running.

Fixes #32 