### PR TITLE
Skip e2e test in all release jobs

### DIFF
--- a/test/e2e/kn_admin_test.go
+++ b/test/e2e/kn_admin_test.go
@@ -108,7 +108,9 @@ func TestKnAdminPlugin(t *testing.T) {
 }
 
 func TestKnAdminPluginWithNoKubectlContext(t *testing.T) {
-	if strings.Contains(os.Getenv("JOB_NAME"), "release") {
+	if strings.Contains(os.Getenv("JOB_NAME"), "release") ||
+		strings.Contains(os.Getenv("JOB_NAME"), "periodic") ||
+		strings.Contains(os.Getenv("JOB_NAME"), "nightly") {
 		t.Skip("Skip in release job, due to serviceAccount clash.")
 	}
 	e2eTest := newE2ETest(t)


### PR DESCRIPTION
Making the condition to skip the flaky test on all release jobs.

This should fix nightly runs for now.

@knative-sandbox/knative-release-leads 